### PR TITLE
respect options set by parent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ ENDIF()
 
 PROJECT( Assimp VERSION 5.0.1 )
 
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif ()
+
 # All supported options ###############################################
 
 OPTION( BUILD_SHARED_LIBS


### PR DESCRIPTION
Setting CMP0077 ensures that projects which include assimp via ExternalProject, FetchContent, and add_subdirectory are able to set options. 